### PR TITLE
lcd.csv

### DIFF
--- a/generators/app/dependencies.json
+++ b/generators/app/dependencies.json
@@ -21,6 +21,7 @@
     "cached-request": "^1.1.2",
     "cliui": "^4.1.0",
     "copy-paste": "^1.3.0",
+    "csv-writer": "^1.5.0",
     "d3-dsv": "^1.0.8",
     "decache": "^4.4.0",
     "del": "^3.0.0",

--- a/generators/app/templates/docs/cms.md
+++ b/generators/app/templates/docs/cms.md
@@ -85,6 +85,10 @@ You can use `gulp cms:info` to output the cms information from the `config.json`
 
 The command `gulp cms:lcd` will output the data that should be inserted into the LCD fields.
 
+`gulp cms:lcd` will now also output a file at `./lcd.csv`, which can be used to mass import LCD fields rather than copying and pasting individually. In the LCD view, you'll see an option called "Import" (it's two below "Edit"). Use the file finder to attach `lcd.csv`.
+
+An important note on this functionality: The gulpfile generates the `./lcd.csv` based on **the most current** build directory. `gulp cms:lcd` does not rerun the build command. This means that if you make changes and do not run `gulp deploy`, `gulp publish` or `gulp develop`, the csv will not reflect those changes. 
+
 This command allows you to get a specific field and copy it to the clipboard. For instance:
 
 - `gulp cms:lcd --get="styles"`

--- a/generators/app/templates/docs/publishing.md
+++ b/generators/app/templates/docs/publishing.md
@@ -18,11 +18,19 @@ The following command-line `gulp` commands will help you along the way. Make sur
 
 ### AWS/S3 integration
 
-The simplest way to publish to S3 is to use the `gulp deploy` command, though you could manually copy the files up if needed to. To make sure the deploy and publish commands work, you will need to have some AWS credentials setup. These can be set as enivonrment variables, and specifically can be set in the `.env` file.
+The simplest way to publish to S3 is to use the `gulp deploy` command, though you could manually copy the files up if needed to. To make sure the deploy and publish commands work, you will need to have some AWS credentials setup.
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- OR have crednetials configured in `~/.aws/crendentials`; and if you manage multiple credneitals, you can utilize `AWS_DEFAULT_PROFILE`.
+The easiest way to do this is by setting up `~/.aws/credentials`. This workflow checks this location by default. If you do not have this set up yet, here's how:
+
+- Open up a new Terminal window and create the hidden folder with this command: `mkdir .aws`
+- cd into the `.aws` folder and create a new file called credentials: `touch credentials`
+- Open this file with vim or another text editor. Your credentials file should look like this:
+```sh
+[default]
+aws_access_key_id = your_actual_access_key_here_you_cant_just_copy_paste_this_code
+aws_secret_access_key = your_actual_secret_access_key_here_you_cant_just_copy_paste_this_code
+```
+- Keep in mind that you can have as many AWS profiles as you want in this file (you can delineate a new profile by putting a new name between the brackets), but when running `gulp deploy` it will use your *default* credentials.
 
 For further reading on setting up access, see [Configuring the JS-SDK](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/configuring-the-jssdk.html).
 

--- a/generators/app/templates/lib/gulp-cms.js
+++ b/generators/app/templates/lib/gulp-cms.js
@@ -11,6 +11,16 @@ const { copy } = require('copy-paste');
 const argv = require('yargs').argv;
 const configUtil = require('./config.js');
 const webpackConfig = require('../webpack.config.js');
+const createCsvWriter = require('csv-writer').createObjectCsvWriter;
+
+//initialize csvwriter for lcd import
+const csvWriter = createCsvWriter({
+  path: './lcd.csv',
+  header: [
+    {id: 'label', title: 'label'},
+    {id: 'content', title: 'content'}
+  ]
+});
 
 // Some basics check of CMS config
 async function cmsConfig() {
@@ -134,6 +144,25 @@ async function lcd() {
       : undefined;
 
     page.parts = parts;
+
+    // use file sync to take a best guess for content field in LCD
+    const pageHTML = fs.readFileSync(
+      path.join(__dirname, '..', parts.contentLocation),
+      'utf-8'
+    );
+
+    // object to write csv to populate lcd fields
+    const records = [
+      {label: 'content', content: pageHTML},
+      {label: 'scripts', content: page.parts.scripts},
+      {label: 'styles', content: page.parts.styles},
+      {label: 'script libraries', content: page.parts['script libraries']},
+      {label: 'style libraries', content: page.parts['style libraries']}
+    ];
+
+    // write the records to lcd.csv
+    csvWriter.writeRecords(records);
+
     return page;
   });
 


### PR DESCRIPTION
In Clickability, there is an option to "import" fields into an LCD via CSV. This PR adds that functionality to our generator.

After running `gulp cms:lcd`, the generator will write the fields generated in the terminal to a file called lcd.csv in the home directory. It's important to note that `gulp cms:lcd` doesn't rerun the build command. 

We may not merge this immediately since other changes to this generator may be on the way soon. 